### PR TITLE
[Dice] Use modifiers with one dice too

### DIFF
--- a/ding-dice/index.js
+++ b/ding-dice/index.js
@@ -30,7 +30,7 @@ if (results[1]>1)
 var totalString=" Total: "+total+".";
 if (results[3])
 	totalString=" Modifying it by "+results[3]+", the total is "+total+".";
-if (results[1]==1)
+if (results[1]==1 && !results[3])
 	totalString="";
 return " rolls "+dice+" "+rolls.join(', ')+"."+totalString;
 }


### PR DESCRIPTION
I was fumbling around just in case I and my group would use this in our D&D sessions (unlikely), and found a really weird behaviour.

```
/dice 1d20+5
Enchanted Judge rolls a die: 3.
```

I mean, what?

This fixes exactly that.

